### PR TITLE
Multithreaded n-grams

### DIFF
--- a/capstone/pom.xml
+++ b/capstone/pom.xml
@@ -33,6 +33,11 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>29.0-jre</version>
+    </dependency>
 
     <!-- Test Dependencies -->
     <dependency>

--- a/capstone/src/main/java/com/google/sps/Objects/TFIDFStringHelper.java
+++ b/capstone/src/main/java/com/google/sps/Objects/TFIDFStringHelper.java
@@ -88,7 +88,7 @@ public class TFIDFStringHelper {
    * Combines two or more HashMaps of n-grams into a single map.
    */
   public static LinkedHashMap<String, Integer> combineMaps(
-      ArrayList<LinkedHashMap<String, Integer>> maps) {
+      List<LinkedHashMap<String, Integer>> maps) {
 
     LinkedHashMap<String, Integer> ngrams = new LinkedHashMap<String, Integer>();
     for (LinkedHashMap<String, Integer> map : maps) {

--- a/capstone/src/main/java/com/google/sps/servlets/TagsTFIDFServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/TagsTFIDFServlet.java
@@ -7,6 +7,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
+import com.google.common.collect.Lists;
 
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -69,17 +70,49 @@ public class TagsTFIDFServlet extends HttpServlet {
       List<String> textData = getGroupPostsText(groupEntity, response);
       addChallengeText(groupEntity, textData, response);
 
-      // TODO: Parallelize this process to occur for each string concurrently.
-      ArrayList<LinkedHashMap<String, Integer>> ngramsList = new ArrayList<>();
-      for (String text : textData) {
-        ngramsList.add(TFIDFStringHelper.ngramTokenizer(text));
-      }
+      List<LinkedHashMap<String, Integer>> ngramsList = createNgrams(textData, response);
       groupMap.put(groupId, TFIDFStringHelper.combineMaps(ngramsList));
     }
 
     return groupMap;
   }
 
+  /**
+   * Given a list of all textual data in a group, divides the list into 4 and 
+   * return a combined list of all ngrams and their frequencies.
+   */
+  private List<LinkedHashMap<String, Integer>> createNgrams(List<String> textData, 
+      HttpServletResponse response) throws IOException {
+    List<LinkedHashMap<String, Integer>> ngramsList;
+    // A synchronized list guarantees that a list is thread-safe.
+    ngramsList = Collections.synchronizedList(new ArrayList<LinkedHashMap<String, Integer>>());
+
+    // Partition textData into sublists of equal size. 
+    // This number can be scaled up as appropriate.
+    List<List<String>> textLists = Lists.partition(textData, 20);
+
+    // Start a new thread for each sublist.
+    List<Thread> threads = new ArrayList<>();
+    for (List<String> textList : textLists) {
+      Thread thread = new Thread(() -> {
+        for (String text : textList) {
+          ngramsList.add(TFIDFStringHelper.ngramTokenizer(text));
+        }
+      });
+      threads.add(thread);
+      thread.start();
+    }
+
+    try {
+      for (Thread thread : threads) {
+        thread.join();
+      }
+    } catch (InterruptedException e) {
+      ErrorHandler.sendError(response, "Thread error when parsing group data. :(");
+    }
+
+    return ngramsList;
+  }
 
   /** 
    * Returns a list of Post content Strings, given a Group entity. 

--- a/capstone/src/main/java/com/google/sps/servlets/TagsTFIDFServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/TagsTFIDFServlet.java
@@ -87,8 +87,7 @@ public class TagsTFIDFServlet extends HttpServlet {
     // A synchronized list guarantees that a list is thread-safe.
     ngramsList = Collections.synchronizedList(new ArrayList<LinkedHashMap<String, Integer>>());
 
-    // Partition textData into sublists of equal size. 
-    // This number can be scaled up as appropriate.
+    // Partition textData into sublists of equal size, which can be scaled up/down as appropriate.
     List<List<String>> textLists = Lists.partition(textData, 20);
 
     // Start a new thread for each sublist.


### PR DESCRIPTION
- Partition textData into sublists of equal size (currently 20, but can be scaled up/down as appropriate)
- Start new threads to process the Strings in each sublist.