### PR TITLE
Group tags front end: show context/usage

### DIFF
--- a/capstone/src/main/java/com/google/sps/Objects/response/TagContextResponse.java
+++ b/capstone/src/main/java/com/google/sps/Objects/response/TagContextResponse.java
@@ -1,0 +1,25 @@
+package com.google.sps.Objects.response;
+
+/**
+ * Used as a wrapper class to contain information needed to convert to JSON to pass to frontend.
+ * Includes the type of data for context, the surrounding text, and the actual tag's text.
+ */
+public class TagContextResponse {
+
+  private String type;
+  private String text;
+  private String tagText;
+
+  /**
+   * Constructor to set instance variables.
+   *
+   * @param type List of Option objects
+   * @param text The text surrounding a tag to provide context for its usage.
+   * @param tagText The tag the user wanted the context of.
+   */
+  public TagContextResponse(String type, String text, String tagText) {
+    this.type = type;
+    this.text = text;
+    this.tagText = tagText;
+  }
+}

--- a/capstone/src/main/java/com/google/sps/servlets/TagsContextServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/TagsContextServlet.java
@@ -1,0 +1,117 @@
+package com.google.sps.servlets;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.gson.Gson;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.EmbeddedEntity;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.sps.Objects.TFIDFStringHelper;
+import com.google.sps.Objects.Tag;
+import com.google.sps.Objects.Comment;
+import com.google.sps.Objects.response.TagContextResponse;
+import error.ErrorHandler;
+
+/** 
+ * Given a group and group tag, this servlet finds and returns all posts, comments, challenges
+ * etc. in which that text appeared. 
+ */
+@WebServlet("/tags-context")
+public class TagsContextServlet extends HttpServlet {
+
+  private DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+  
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Long groupId = Long.parseLong(request.getParameter("groupId"));
+    String tagText = request.getParameter("tag");
+
+    Entity groupEntity = ServletHelper.getEntityFromId(response, groupId, datastore, "Group");
+
+    ArrayList<TagContextResponse> contexts = new ArrayList<>();
+
+    addMatchingPosts(groupEntity, contexts, tagText, response);
+    addMatchingChallenges(groupEntity, contexts, tagText, response);
+
+    // Convert to json
+    response.setContentType("application/json;");
+    response.getWriter().println(new Gson().toJson(contexts));
+  }
+
+  /** 
+   * Queries the database to find all Posts within Group that contain the tag,
+   * and add it to the list of contexts.
+   */
+  private void addMatchingPosts(Entity groupEntity, ArrayList<TagContextResponse> contexts, 
+      String tagText, HttpServletResponse response) throws IOException {
+    List<Long> postIds = (ArrayList<Long>) groupEntity.getProperty("posts");
+    
+    if (postIds != null) {
+      for (long postId : postIds) {
+        Entity postEntity = ServletHelper.getEntityFromId(response, postId, datastore, "Post");
+        String postText = (String) postEntity.getProperty("postText");
+
+        if (TFIDFStringHelper.sanitize(postText).contains(tagText)) {
+          contexts.add(new TagContextResponse("Post", postText, tagText));
+        }
+
+        addMatchingComments(postEntity, contexts, tagText);
+      }
+    }
+  }
+
+  /**
+   * Queries the database to find all comments within Group that contain the tag,
+   * and add it to the list of contexts.
+   */
+  private void addMatchingComments(Entity postEntity, ArrayList<TagContextResponse> contexts, 
+      String tagText) {
+    
+    ArrayList<EmbeddedEntity> comments = 
+        (ArrayList<EmbeddedEntity>) postEntity.getProperty("comments");
+
+    if (comments != null) {
+      for (EmbeddedEntity commentEntity : comments) {
+        String commentText = (String) commentEntity.getProperty("commentText");
+        
+        if (TFIDFStringHelper.sanitize(commentText).contains(tagText)) {
+          contexts.add(new TagContextResponse("Comment", commentText, tagText));
+        }
+      }
+    }
+  }
+  
+
+  /** 
+   * Queries the database to find all Challenges within Group that contain the tag,
+   * and add it to the list of contexts.
+   */
+  private void addMatchingChallenges(Entity groupEntity, ArrayList<TagContextResponse> contexts, 
+      String tagText, HttpServletResponse response) throws IOException {
+    List<Long> challengeIds = (ArrayList<Long>) groupEntity.getProperty("challenges");
+    
+    if (challengeIds != null) {
+      for (long challengeId : challengeIds) {
+        Entity challengeEntity = 
+          ServletHelper.getEntityFromId(response, challengeId, datastore, "Challenge");
+        String challengeName = (String) challengeEntity.getProperty("name");
+
+        if (TFIDFStringHelper.sanitize(challengeName).contains(tagText)) {
+          contexts.add(new TagContextResponse("Challenge", challengeName, tagText));
+        }
+      }
+    }
+  }
+}

--- a/capstone/src/main/java/com/google/sps/servlets/TagsTFIDFServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/TagsTFIDFServlet.java
@@ -24,7 +24,10 @@ import com.google.sps.Objects.Tag;
 import com.google.sps.Objects.Comment;
 import error.ErrorHandler;
 
-/** This servlet generates groups "tags" for all groups - calculated using TF-IDF. */
+/** 
+ * This servlet generates groups "tags" for all groups - calculated using TF-IDF. 
+ * It is called every day via Cloud Scheduler.
+ */
 @WebServlet("/tags-tfidf")
 public class TagsTFIDFServlet extends HttpServlet {
 

--- a/capstone/src/main/webapp/group.html
+++ b/capstone/src/main/webapp/group.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <link
-      href="https://fonts.googleapis.com/css?family=Roboto"
+      href="https://fonts.googleapis.com/css?family=Roboto:400,500,700"
       rel="stylesheet"
       type="text/css"
     />
@@ -27,7 +27,7 @@
   <body onload="init()">
     <div class=sidebar>
       <div id=navbar class="navbar">
-        <a id="logout-btn" title="Logout"><img src="images/logout.svg"></img></a>
+        <a id="logout-btn" title="Logout"><img src="images/logout.svg" alt="logout"></a>
         <a id="profile-btn" href="profile.html" title="Profile"></a>
       </div>
 
@@ -113,6 +113,14 @@
              These are updated every day, so if you make new posts or comments,
              check back tomorrow to see if there's a change!
           </p>
+        </div>
+      </div>
+
+      <div class="tags-context-modal" id="tags-context-modal">
+        <div class="tags-context-content">
+          <span id="context-close">&times;</span>
+          <h2 id="tag-name"></h2>
+          <div id="context-container"></div>
         </div>
       </div>
         

--- a/capstone/src/main/webapp/scripts/profile.js
+++ b/capstone/src/main/webapp/scripts/profile.js
@@ -24,7 +24,7 @@ function loadPage() {
   getUserData();
   createLogoutUrl();
 
-  tfidf(); // test - won't always be called from here
+  //tfidf();
 }
 
 /*
@@ -220,7 +220,8 @@ function createGroup() {
 /**
  * Call servlet to generate group tags.
  * This is just a test function, eventually it will be called via cron job.
- */
+ *
 function tfidf() {
   fetch("/tags-tfidf");
 }
+ */

--- a/capstone/src/main/webapp/scripts/tags.js
+++ b/capstone/src/main/webapp/scripts/tags.js
@@ -16,9 +16,13 @@ function displayTags(tags) {
       tagContainer.appendChild(text);
   } else {
     for (tag of tags) {
+      let tagName = tag.text;
       const tagElement = document.createElement('span');
       tagElement.id = 'tag';
-      tagElement.innerText = tag.text;
+      tagElement.innerText = tagName;
+      tagElement.addEventListener("click", function () {
+        openTagsContext(tagName);
+      });
       tagContainer.appendChild(tagElement);
     }
   }
@@ -32,4 +36,42 @@ function openAboutTags() {
   let modal = document.getElementById('about-tags-modal');
   modal.style.display = "block"
   addModalListeners('about-tags-modal', 'about-close');
+}
+
+
+/** 
+ * Opens a modal that shows the usage of a tag in the context of 
+ * the group's posts, comments, etc. 
+ */
+function openTagsContext(tag) {
+  const tagNameElement = document.getElementById('tag-name');
+  tagNameElement.innerHTML = 'Usage of tag: ' + tag;
+
+  fetch(`/tags-context?groupId=${groupId}&tag=${tag}`)
+  .then(response => response.json())
+  .then((contextText) => {  
+    let modal = document.getElementById('tags-context-modal');
+    displayTagContext(contextText);
+    modal.style.display = "block"
+    addModalListeners('tags-context-modal', 'context-close');
+  });
+}
+
+/** Display the context of a given tag. */
+function displayTagContext(contextText) {
+  const container = document.getElementById('context-container');
+  container.innerHTML = "";
+
+  for (context of contextText) {
+    const textElement = document.createElement('p');
+    textElement.id = 'context-text';
+    const boldedText = boldTag(context.text, context.tagText);
+    textElement.innerHTML = `${context.type}:	${boldedText}`;
+    container.appendChild(textElement);
+  }
+}
+
+/** Bold the given part of a text. */
+function boldTag(text, tag) {
+  return text.replace(new RegExp('(^|\\W)(' + tag + ')(\\W|$)','ig'), '$1<strong>$2</strong>$3');
 }

--- a/capstone/src/main/webapp/styles/members.css
+++ b/capstone/src/main/webapp/styles/members.css
@@ -63,7 +63,7 @@
 .member-content,
 .add-member-content {
   background-color: var(--near-white);
-  margin: auto;
+  margin: 0 auto;
   padding: 25px 30px;
   border: 1px solid #888;
   width: 30%;

--- a/capstone/src/main/webapp/styles/tags.css
+++ b/capstone/src/main/webapp/styles/tags.css
@@ -22,11 +22,16 @@
 #group-tags #tag {
   border-radius: 20px;
   color: white;
+  cursor: pointer;
   display: inline-block;
   margin: 10px;
   min-width: 90px;
   padding: 10px;
   text-align: center;
+}
+
+#tag:hover {
+  color: var(--text-gray);
 }
 
 #tag:nth-child(3n+1) {
@@ -51,6 +56,7 @@
 }
 
 /* Modal background */
+.tags-context-modal,
 .about-tags-modal {
   display: none;
   visibility: none;
@@ -66,24 +72,33 @@
 }
 
 /* Modal Content */
+.tags-context-content,
 .about-tags-content {
   background-color: var(--near-white);
-  margin: auto;
   padding: 15px 20px;
   border: 1px solid #888;
-  width: 20%;
+  border-radius: 5px;
+  margin: 0 auto;
+  width: 20rem;
 }
 
+.tags-context-content{
+  width: 40rem;
+}
+
+.tags-context-content h2,
 .about-tags-content h2 {
   font-size: 22px;
   font-weight: bold;
   margin: 10px 10px 20px 0px;
 }
 
+.tags-context-content p,
 .about-tags-content p {
   font-size: 16px;
 }
 
+#context-close,
 #about-close {
   color: #aaaaaa;
   float: right;
@@ -91,6 +106,8 @@
   font-weight: bold;
 }
 
+#context-close:hover,
+#context-close:focus,
 #about-close:hover, 
 #about-close:focus {
   color: var(--black);

--- a/capstone/src/test/java/com/google/sps/servlets/TagsContextServletTest.java
+++ b/capstone/src/test/java/com/google/sps/servlets/TagsContextServletTest.java
@@ -1,0 +1,202 @@
+package com.google.sps.servlets;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EmbeddedEntity;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalUserServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.common.collect.ImmutableMap;
+import java.util.HashSet;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Arrays;
+import com.google.gson.Gson;
+import com.google.sps.Objects.TFIDFStringHelper;
+import com.google.sps.Objects.Group;
+import com.google.sps.Objects.Tag;
+import com.google.sps.Objects.Challenge;
+import com.google.sps.Objects.Post;
+import com.google.sps.Objects.Comment;
+import com.google.sps.Objects.response.TagContextResponse;
+
+
+/**
+ * Unit tests for {@link TagsTFIDFServlet}.
+ */
+ @RunWith(JUnit4.class)
+public class TagsContextServletTest {
+  private final long GROUP_ID = 10;
+  private final String USER_ID = "User";
+  private final String USER_EMAIL = "test@test.com";
+
+  private final String POST_TEXT_1 = "This is a great post!";
+  private final String POST_TEXT_2 = "This is another post!";
+  private final String CHALLENGE_NAME = "Not a Post.";
+  private final String IMG = "";
+  private final long TIMESTAMP = 123123123;
+
+  private final Post POST_1 = 
+      new Post(
+          0, /* postId */
+          USER_ID, /* authorId */
+          POST_TEXT_1, /* postText */
+          new ArrayList<Comment>(), /* comments */
+          CHALLENGE_NAME, /* challengeName */
+          TIMESTAMP, /* timestamp */
+          IMG, /* img */
+          new HashSet<String>() /* likes */);
+  
+  private final Post POST_2 = 
+      new Post(
+          0, /* postId */
+          USER_ID, /* authorId */
+          POST_TEXT_2, /* postText */
+          new ArrayList<Comment>(), /* comments */
+          CHALLENGE_NAME, /* challengeName */
+          TIMESTAMP, /* timestamp */
+          IMG, /* img */
+          new HashSet<String>() /* likes */);
+
+  private final Challenge CHALLENGE_1 = 
+      new Challenge(
+          CHALLENGE_NAME, /* challengeName */
+          12345, /* dueDate */
+          null, /* badge */
+          new ArrayList<String>(), /* usersCompleted */
+          0 /* id */);
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(
+              new LocalDatastoreServiceTestConfig()
+                  .setDefaultHighRepJobPolicyUnappliedJobPercentage(0),
+              new LocalUserServiceTestConfig())
+          .setEnvEmail(USER_EMAIL)
+          .setEnvIsLoggedIn(true)
+          .setEnvAuthDomain("gmail.com")
+          .setEnvAttributes(
+              new HashMap(
+                  ImmutableMap.of(
+                      "com.google.appengine.api.users.UserService.user_id_key", USER_ID)));
+
+  @Mock private HttpServletRequest mockRequest;
+  @Mock private HttpServletResponse mockResponse;
+  private StringWriter responseWriter;
+  private DatastoreService datastore;
+  private TagsContextServlet tagsContextServlet;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    helper.setUp();
+
+    datastore = DatastoreServiceFactory.getDatastoreService();
+    populateDatabase(datastore);
+
+    // Set up a fake HTTP response.
+    responseWriter = new StringWriter();
+    when(mockResponse.getWriter()).thenReturn(new PrintWriter(responseWriter));
+
+    tagsContextServlet = new TagsContextServlet();
+  }
+
+  @After
+  public void tearDown() {
+    // tear down work
+  }
+
+  @Test
+  public void doGet_returnOnePost() throws Exception {
+    when(mockRequest.getParameter("groupId")).thenReturn(Long.toString(GROUP_ID));
+    when(mockRequest.getParameter("tag")).thenReturn("a great");
+
+    tagsContextServlet.doGet(mockRequest, mockResponse);
+    String response = responseWriter.toString();
+
+    assertTrue(response.contains(POST_TEXT_1) && 
+              !response.contains(POST_TEXT_2));
+  }
+
+  @Test
+  public void doGet_returnAll() throws Exception {
+    when(mockRequest.getParameter("groupId")).thenReturn(Long.toString(GROUP_ID));
+    when(mockRequest.getParameter("tag")).thenReturn("post");
+
+    tagsContextServlet.doGet(mockRequest, mockResponse);
+    String response = responseWriter.toString();
+
+    assertTrue(response.contains(POST_TEXT_1) && 
+               response.contains(POST_TEXT_2) &&
+               response.contains(CHALLENGE_NAME));
+  }
+
+  @Test
+  public void doGet_returnNone() throws Exception {
+    when(mockRequest.getParameter("groupId")).thenReturn(Long.toString(GROUP_ID));
+    when(mockRequest.getParameter("tag")).thenReturn("comment");
+
+    tagsContextServlet.doGet(mockRequest, mockResponse);
+    String response = responseWriter.toString();
+
+    assertTrue(!response.contains(POST_TEXT_1) && 
+               !response.contains(POST_TEXT_2));
+  }
+
+  private void populateDatabase(DatastoreService datastore) {
+    Entity groupEntity = new Entity("Group", GROUP_ID);
+    groupEntity.setProperty("groupName", "Name");
+    groupEntity.setProperty("headerImg", "");
+    groupEntity.setProperty("memberIds", new ArrayList<String>());
+    groupEntity.setProperty("posts", addPosts());
+    groupEntity.setProperty("options", new ArrayList<Long>());
+    groupEntity.setProperty("challenges", addChallenges());
+    groupEntity.setProperty("tags", new ArrayList<Tag>());
+    datastore.put(groupEntity);
+  }
+
+  private ArrayList<Long> addPosts() {
+    ArrayList<Long> postIds = new ArrayList<>();
+
+    Entity postEntity1 = POST_1.toEntity();
+    Entity postEntity2 = POST_2.toEntity();
+
+    datastore.put(postEntity1);
+    datastore.put(postEntity2);
+
+    postIds.add(postEntity1.getKey().getId());
+    postIds.add(postEntity2.getKey().getId());
+
+    return postIds;
+  }
+
+  private ArrayList<Long> addChallenges() {
+    ArrayList<Long> challengeIds = new ArrayList<>();
+
+    Entity challengeEntity = CHALLENGE_1.toEntity();
+
+    datastore.put(challengeEntity);
+
+    challengeIds.add(challengeEntity.getKey().getId());
+
+    return challengeIds;
+  }
+} 


### PR DESCRIPTION
- When clicking a tag, a modal opens that shows the user where those words were used in the context of the Group's posts, comments, and challenges.

![image](https://user-images.githubusercontent.com/30757425/89080825-f12b8c80-d357-11ea-86cd-def2eb25adcc.png)
![image](https://user-images.githubusercontent.com/30757425/89080828-f4267d00-d357-11ea-9a04-d2e34101bd36.png)

**Additional note**: 
I used the Google Cloud Scheduler API to schedule a cron job that calls the tags-tfidf servlet every 24 hours. However, that is only called on the deployed version, so I've left the function commented out in `profile.js` for now, in case we need to uncomment and run the calculation the dev server for testing purposes.