### PR TITLE
Challenges on profile

### DIFF
--- a/capstone/src/main/java/com/google/sps/Objects/response/UserGroupResponse.java
+++ b/capstone/src/main/java/com/google/sps/Objects/response/UserGroupResponse.java
@@ -1,8 +1,9 @@
 package com.google.sps.Objects.response;
 
-import com.google.appengine.api.datastore.Entity;
 import java.util.ArrayList;
+import com.google.appengine.api.datastore.Entity;
 import com.google.sps.Objects.Challenge;
+import com.google.sps.servlets.ServletHelper;
 
 /**
  * Used as a wrapper class to contain information needed to convert to JSON to
@@ -13,7 +14,7 @@ import com.google.sps.Objects.Challenge;
  */
 public final class UserGroupResponse {
 
-  private final ArrayList<Challenge> challenges;
+  private ArrayList<Challenge> challenges;
   private final String groupName;
   private final String headerImg;
   private final long groupId;
@@ -33,11 +34,12 @@ public final class UserGroupResponse {
     long groupId = (long) entity.getKey().getId();
     String groupName = (String) entity.getProperty("groupName");
     String headerImg = (String) entity.getProperty("headerImg");
-    // TODO: fix below code, won't work with Challenges as EmbeddedEntities of Groups
-    ArrayList<Challenge> challenges = (entity.getProperty("challenges") == null)
-        ? new ArrayList<>()
-        : (ArrayList<Challenge>) entity.getProperty("challenges");
+    ArrayList<Challenge> challenges = new ArrayList<>();
     UserGroupResponse response = new UserGroupResponse(challenges, groupName, headerImg, groupId);
     return response;
   }
+
+  public void setChallenges(ArrayList<Challenge> challenges) {
+    this.challenges = challenges;
+  } 
 }

--- a/capstone/src/main/java/com/google/sps/servlets/UserGroupsServlet.java
+++ b/capstone/src/main/java/com/google/sps/servlets/UserGroupsServlet.java
@@ -113,7 +113,7 @@ public class UserGroupsServlet extends AuthenticatedServlet {
   }
 
   /**
-   * Returns a list of the user's challenges given a groupEntity.
+   * Returns a list of the user's ongoing challenges given a groupEntity.
    */
   private ArrayList<Challenge> getGroupChallenges(String userId, Entity groupEntity,
       HttpServletResponse response) throws IOException {
@@ -125,23 +125,13 @@ public class UserGroupsServlet extends AuthenticatedServlet {
             : (ArrayList<Long>) groupEntity.getProperty("challenges");
 
     if (challengeIds.size() != 0) {
-      // Add ongoing challenge to list first.
+      // Add ongoing challenge.
       long mostRecentChallengeId = challengeIds.get(challengeIds.size() - 1);
       Entity newestChallengeEntity =
           ServletHelper.getEntityFromId(response, mostRecentChallengeId, datastore, "Challenge");
       if (newestChallengeEntity != null && 
           (long) newestChallengeEntity.getProperty("dueDate") >= System.currentTimeMillis()) {
         challenges.add(Challenge.fromEntity(newestChallengeEntity));
-      }
-
-      // Next, add all completed challenges.
-      for (Long challengeId : challengeIds) {
-        Entity challengeEntity = 
-          ServletHelper.getEntityFromId(response, challengeId, datastore, "Challenge");
-        Challenge challenge = Challenge.fromEntity(challengeEntity);
-        if (challenge.getHasUserCompleted(userId)) {
-          challenges.add(challenge);
-        }
       }
     }
 

--- a/capstone/src/main/webapp/profile.html
+++ b/capstone/src/main/webapp/profile.html
@@ -43,8 +43,6 @@
           <div id="groups-container"></div>
           <h1 id="ongoing-challenges">Ongoing Challenges</h1>
           <div id="ongoing-container"></div>
-          <h1 id="past-challenges">Past Challenges</h1>
-          <div id="past-container"></div>
         </div>
       </div>
     </div>

--- a/capstone/src/main/webapp/profile.html
+++ b/capstone/src/main/webapp/profile.html
@@ -42,7 +42,9 @@
           <h1 id="groups">Groups</h1>
           <div id="groups-container"></div>
           <h1 id="ongoing-challenges">Ongoing Challenges</h1>
+          <div id="ongoing-container"></div>
           <h1 id="past-challenges">Past Challenges</h1>
+          <div id="past-container"></div>
         </div>
       </div>
     </div>
@@ -105,11 +107,13 @@
 
     <template id="challenge-template">
       <div class="challenge-container">
-        <div id="group-name" class="group-name"></div>
-        <div id="challenge-content">
-          <p id="challenge-name" class="challenge-name"></p>
-          <p id="due date"></p>
-        </div>
+        <a id="challenge-group-link">
+          <div id="challenge-group-name" class="group-name"></div>
+          <div class="challenge-content">
+            <p id="challenge-name" class="challenge-name"></p>
+            <p id="due-date"></p>
+          </div>
+        </a>
       </div>
     </template>
 

--- a/capstone/src/main/webapp/scripts/profile.js
+++ b/capstone/src/main/webapp/scripts/profile.js
@@ -128,7 +128,53 @@ function displayGroups(groups) {
 }
 
 /** Display the user's ongoing and past challenges  */
-function displayChallenges(groups) {}
+function displayChallenges(groups) {
+  console.log("Displaying challenges"); //test
+
+  let pastChallenges = [];
+
+  for (group of groups) {
+    const length = Object.keys(group.challenges).length;
+    if (length > 0) {
+      for (let i = 0; i < length; i++) {
+        let challenge = (group.challenges)[i];      
+        if (i == 0) {
+          addOngoingChallenge(challenge, group);
+        } else {
+          pastChallenges.push[challenge];
+        }
+      }
+    }
+  }
+
+  addPastChallenges(pastChallenges);
+}
+
+/** Display the user's ongoing and past challenges  */
+function addOngoingChallenge(challenge, group) {
+  const ongoingContainer = document.getElementById("ongoing-container");
+  const challengeElement = document.getElementById("challenge-template");
+
+  let challengeElementNode = document.importNode(challengeElement.content, true);
+
+  let challengeContainer = challengeElementNode.querySelector(".challenge-container");
+
+  let groupName = challengeElementNode.getElementById("challenge-group-name");
+  groupName.innerText = group.groupName;
+
+  let groupLink = challengeElementNode.getElementById("challenge-group-link");
+  groupLink.href = "group.html?groupId=" + group.groupId;
+
+  let challengeName = challengeElementNode.getElementById("challenge-name");
+  challengeName.innerText = challenge.challengeName;
+
+  let dueDateContainer = challengeElementNode.getElementById("due-date");
+  const dueDate = new Date(challenge.dueDate).toString();
+  dueDateContainer.innerText = `Due: ${dueDate}`;
+
+  ongoingContainer.appendChild(challengeElementNode);
+  console.log("Appended an ongoing challenge"); //test
+}
 
 /** Display the user's earned badges  */
 function displayBadges(badges) {

--- a/capstone/src/main/webapp/scripts/profile.js
+++ b/capstone/src/main/webapp/scripts/profile.js
@@ -129,28 +129,15 @@ function displayGroups(groups) {
 
 /** Display the user's ongoing and past challenges  */
 function displayChallenges(groups) {
-  console.log("Displaying challenges"); //test
-
-  let pastChallenges = [];
-
   for (group of groups) {
-    const length = Object.keys(group.challenges).length;
-    if (length > 0) {
-      for (let i = 0; i < length; i++) {
-        let challenge = (group.challenges)[i];      
-        if (i == 0) {
-          addOngoingChallenge(challenge, group);
-        } else {
-          pastChallenges.push[challenge];
-        }
-      }
+    if (Object.keys(group.challenges).length > 0) {
+      let challenge = (group.challenges)[0];
+      addOngoingChallenge(challenge, group);
     }
   }
-
-  addPastChallenges(pastChallenges);
 }
 
-/** Display the user's ongoing and past challenges  */
+/** Display the user's ongoing challenges  */
 function addOngoingChallenge(challenge, group) {
   const ongoingContainer = document.getElementById("ongoing-container");
   const challengeElement = document.getElementById("challenge-template");
@@ -173,7 +160,6 @@ function addOngoingChallenge(challenge, group) {
   dueDateContainer.innerText = `Due: ${dueDate}`;
 
   ongoingContainer.appendChild(challengeElementNode);
-  console.log("Appended an ongoing challenge"); //test
 }
 
 /** Display the user's earned badges  */

--- a/capstone/src/main/webapp/styles/profile.css
+++ b/capstone/src/main/webapp/styles/profile.css
@@ -138,13 +138,14 @@
   background-color: var(--header-green);
 }
 
+/* Groups */
 .main .group-container {
   display: flex;
   flex-direction: column;
   width: 600px;
 }
 
-.main .groups-container a,
+.main .groups-container .challenge-container a,
 a:link, a:visited, a:hover, a:active {
   text-decoration: none;
 }
@@ -155,8 +156,10 @@ a:link, a:visited, a:hover, a:active {
   color: white;
   margin: -10px 0 10px;
   padding: 10px 0;
+  position: relative;
   text-align: center;
   width: 100%;
+  z-index: 1;
 }
 
 .main .header-img {
@@ -164,6 +167,33 @@ a:link, a:visited, a:hover, a:active {
   border-radius: 10px;
   height: 200px;
   width: 100%;
+}
+
+/* Challenges */
+.main .challenge-container {
+  display: flex;
+  flex-direction: column;
+  width: 600px;
+}
+
+.main .challenge-content {
+  background: var(--near-white);
+  border-radius: 10px;
+  box-sizing: border-box;
+  color: black;
+  margin: -15px 0 10px;
+  padding: 20px 30px;
+  position: relative;
+  z-index: 0;
+}
+
+#challenge-group-name.group-name {
+  margin: 0;
+}
+
+#due-date {
+  color: var(--text-gray);
+  font-size: 13px;
 }
 
 #logout-btn {

--- a/capstone/src/main/webapp/styles/profile.css
+++ b/capstone/src/main/webapp/styles/profile.css
@@ -181,7 +181,7 @@ a:link, a:visited, a:hover, a:active {
   border-radius: 10px;
   box-sizing: border-box;
   color: black;
-  margin: -15px 0 10px;
+  margin: -15px 0 15px;
   padding: 20px 30px;
   position: relative;
   z-index: 0;


### PR DESCRIPTION
- Display a user's ongoing challenges on their profile page.
- A user can click on each challenge to get taken to the corresponding group.
- A user cannot mark a challenge as completed from the profile page and must go through the group page first. (Should I change this?)

Screenshot:
![image](https://user-images.githubusercontent.com/30757425/89216145-ee1edf00-d597-11ea-853b-b36e3dcdc528.png)

**Note**: Removed past/completed challenges as it would require a little bit of restructuring of the code and I wasn't sure if it was worth it for the MVP. If I find myself with some extra time tomorrow I'll add it.