### PR TITLE
Reduce New Map Calls 

### DIFF
--- a/capstone/src/main/webapp/scripts/group.js
+++ b/capstone/src/main/webapp/scripts/group.js
@@ -11,9 +11,14 @@ function init() {
   getPollOptions();
   fetchBlobstoreUrlAndShowForm();
   loadMembers();
-  loadClosestGroupLocations();
+  initializeNearestLocations();
   autocomplete();
   loadTags();
+}
+
+function initializeNearestLocations() {
+  let locations_content = document.getElementById('group-locations-content');
+  locations_content.style.display = 'none';
 }
 
 /** Fetch current user's data from the server */

--- a/capstone/src/main/webapp/scripts/group.js
+++ b/capstone/src/main/webapp/scripts/group.js
@@ -77,7 +77,11 @@ function loadClosestGroupLocations() {
       }
       let mapElement = document.getElementById('map');
       mapElement.style.display = "block";
-      createMap(allCentralGroupLocations, locationsLimit);
+      if (map == null) {
+        createMap(allCentralGroupLocations, locationsLimit);
+      } else {
+        addMarkers(allCentralGroupLocations, locationsLimit);
+      }
     }
   });
 }

--- a/capstone/src/main/webapp/scripts/map.js
+++ b/capstone/src/main/webapp/scripts/map.js
@@ -1,10 +1,23 @@
 let map;
 let markerBounds;
+let markers = [];
 function createMap(allCentralGroupLocations, locationsLimit) {
   map = new google.maps.Map(
       document.getElementById('map'),
       {center: {lat: allCentralGroupLocations[0].coordinate.latitude, lng: allCentralGroupLocations[0].coordinate.longitude}, zoom: 10.0}); 
   
+  addMarkers(allCentralGroupLocations, locationsLimit);
+}
+
+function removeMarkers(){
+  for (let i = 0; i < markers.length; i++) {
+    markers[i].setMap(null);
+  }
+}
+
+function addMarkers(allCentralGroupLocations, locationsLimit) {
+  removeMarkers();
+  markers = [];
   markerBounds = new google.maps.LatLngBounds();
 
   for (let i = 1; i < locationsLimit + 1; i++) {
@@ -26,7 +39,7 @@ function toggleLocationVisibility() {
 
 function addLocationMarker(location) {
   locationPoint = new google.maps.LatLng(location.coordinate.latitude, location.coordinate.longitude);
-  const locationMarker = new google.maps.Marker({
+  const marker = new google.maps.Marker({
     position: locationPoint,
     map: map,
     title: `${location.locationName}`
@@ -35,10 +48,8 @@ function addLocationMarker(location) {
 
   let contentString = "<p class='marker-text'>" + location.locationName + "</p> <p class='marker-text'>" + location.address + "</p>";
   const infoWindow = new google.maps.InfoWindow({content: contentString});
-  locationMarker.addListener('click', () => {
-    infoWindow.open(map, locationMarker);
+  marker.addListener('click', () => {
+    infoWindow.open(map, marker);
   });
+  markers.push(marker);
 }
-
-
-

--- a/capstone/src/main/webapp/scripts/map.js
+++ b/capstone/src/main/webapp/scripts/map.js
@@ -34,6 +34,7 @@ function toggleLocationVisibility() {
     locations_content.style.display = 'none';
   } else {
     locations_content.style.display = 'block';
+    loadClosestGroupLocations();
   }
 }
 


### PR DESCRIPTION
(https://developers.google.com/maps/documentation/javascript/usage-and-billing)
Reduced the number of Javascript map loads 
1) When switching between 1/5/10/15/20 nearest locations, remove markers and add markers to existing map (before I was creating a new map every time)
2) Nearest group locations not shown on page load and clicking on title opens the section (this way a new map is not created on every page reload)